### PR TITLE
Shell image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:jessie
+MAINTAINER Jonathon M. Abbott <jonathona@everydayhero.com.au>
+
+ADD . /build
+RUN /build/build.sh
+
+ENTRYPOINT ["/usr/local/bin/user-enter.sh"]
+CMD ["/bin/bash"]

--- a/bin/run-shell
+++ b/bin/run-shell
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONFIG_FILE=~/.dockershellrc
+CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/docker-shell"
 
 plain_shell_env() {
 cat <<EOF

--- a/bin/run-shell
+++ b/bin/run-shell
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+CONFIG_FILE=~/.dockershellrc
+
+plain_shell_env() {
+cat <<EOF
+PLAIN_SHELL_DOCKER_GID=$(getent group docker | cut -f 3-3 -d:)
+PLAIN_SHELL_USERNAME=$(id -un)
+PLAIN_SHELL_GROUP=$(id -gn)
+PLAIN_SHELL_UID=$(id -u)
+PLAIN_SHELL_GID=$(id -g)
+PLAIN_SHELL_SHELL=/bin/bash
+EOF
+}
+
+[ -f "$CONFIG_FILE" ] && source "$CONFIG_FILE"
+
+docker run --rm -it \
+  -v $SSH_AUTH_SOCK:/srv/ssh-auth.sock \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  --env SSH_AUTH_SOCK=/srv/ssh-auth.sock \
+  --env-file <(plain_shell_env) \
+  --privileged=true \
+  -v ${PLAIN_SHELL_HOME:-${HOME}}:/home/$(id -un) \
+  "${PLAIN_SHELL_IMAGE:-quay.io/everydayhero/shell}" \
+  "$@"

--- a/build-00-prepare.sh
+++ b/build-00-prepare.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+source /build/buildconfig
+set -x
+
+## Temporarily disable dpkg fsync to make building faster.
+if [[ ! -e /etc/dpkg/dpkg.cfg.d/docker-apt-speedup ]]; then
+	echo force-unsafe-io > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup
+fi
+
+## Use cloudfront debian mirror
+sed -i -e 's,httpredir.debian.org,cloudfront.debian.net,' /etc/apt/sources.list
+apt-get update
+
+## Install HTTPS support for APT.
+$minimal_apt_get_install apt-transport-https ca-certificates
+
+# Install debconf utils
+$minimal_apt_get_install debconf-utils
+
+## Upgrade all packages.
+apt-get dist-upgrade -y --no-install-recommends
+
+cat <<EOF | debconf-set-selections
+locales locales/default_environment_locale  select  en_US.UTF-8
+locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8
+EOF
+
+$minimal_apt_get_install locales

--- a/build-01-install.sh
+++ b/build-01-install.sh
@@ -4,6 +4,7 @@ source /build/buildconfig
 set -x
 
 PACKAGES="
+  ansible
   build-essential
   curl
   git

--- a/build-01-install.sh
+++ b/build-01-install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+source /build/buildconfig
+set -x
+
+PACKAGES="
+  build-essential
+  curl
+  git
+  procps
+  sudo
+  vim-nox
+  wget
+"
+
+$minimal_apt_get_install $PACKAGES

--- a/build-01-install.sh
+++ b/build-01-install.sh
@@ -5,7 +5,6 @@ set -x
 
 PACKAGES="
   ansible
-  build-essential
   curl
   git
   openssh-client

--- a/build-01-install.sh
+++ b/build-01-install.sh
@@ -8,6 +8,7 @@ PACKAGES="
   build-essential
   curl
   git
+  openssh-client
   procps
   sudo
   vim-nox

--- a/build-02-userenter.sh
+++ b/build-02-userenter.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+source /build/buildconfig
+set -x
+
+cp /build/user-enter.sh /usr/local/bin

--- a/build-03-install-docker.sh
+++ b/build-03-install-docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+source /build/buildconfig
+set -x
+
+docker_version=1.5.0
+
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+
+echo "deb https://get.docker.io/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
+
+apt-get update
+apt-get install -y lxc-docker-$docker_version

--- a/build-99-cleanup.sh
+++ b/build-99-cleanup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+source /build/buildconfig
+set -x
+
+apt-get clean
+rm -rf /build
+rm -rf /tmp/* /var/tmp/*
+rm -rf /var/lib/apt/lists/*
+rm -f /etc/dpkg/dpkg.cfg.d/docker-apt-speedup
+
+# rm -f /etc/ssh/ssh_host_*

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+DIR=$(realpath "$(dirname "$0")")
+
+cd "$DIR"
+
+ls build-*.sh | while read script; do
+  ./$script
+done

--- a/buildconfig
+++ b/buildconfig
@@ -1,0 +1,3 @@
+export LC_ALL=C
+export DEBIAN_FRONTEND=noninteractive
+minimal_apt_get_install='apt-get install -y --no-install-recommends'

--- a/user-enter.sh
+++ b/user-enter.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+sed -i -e "s,docker:x:[0-9]*:,docker:x:${PLAIN_SHELL_DOCKER_GID}:,g" /etc/group
+groupadd -g $PLAIN_SHELL_GID $PLAIN_SHELL_GROUP
+useradd -u $PLAIN_SHELL_UID -g $PLAIN_SHELL_GID -Ms $PLAIN_SHELL_SHELL $PLAIN_SHELL_USERNAME
+gpasswd -a $PLAIN_SHELL_USERNAME docker >/dev/null
+gpasswd -a $PLAIN_SHELL_USERNAME sudo >/dev/null
+yes "$PLAIN_SHELL_USERNAME" | passwd $PLAIN_SHELL_USERNAME 2>/dev/null
+
+exec sudo SSH_AUTH_SOCK="$SSH_AUTH_SOCK" -u $PLAIN_SHELL_USERNAME -i "$@"


### PR DESCRIPTION
A minimal debian userland image with some unique features.
## Usage

```
bin/run-shell [command ...]
```

Runs a docker container using the shell image. With no arguments it launches a shell, otherwise it runs the specified command (as a non-root user). Your home directory on the host will be available inside the container.
## Feature
- allows use of arbitrary userids and names as the executing user instead of root (very helpful if you want to access user files on the host, otherwise, enjoy cleaning up after the root-owned droppings that get left behind)
- forwards host-level SSH_AUTH_SOCK
- forwards host-level docker access
- the user you run as has `sudo` and `docker` access so you can basically do whatever you want inside the container
- includes some basic tools
  - vim
  - git
  - curl/wget
  - ssh
  - procps (ps/kill etc.)
  - sudo
  - ansible
  - docker client

The Dockerfile itself is optimized for slim final images, with a single RUN command that cleans up after itself. (I borrowed this approach from baseimage-docker and adjusted it slightly to debian.)
## Details

The run-as-an-actual-user magic is implemented in the entrypoint user-enter.sh which expects various environment variables to be set. These are set automatically by the `bin/run-shell` launcher.
